### PR TITLE
add custom channels to construct.yaml

### DIFF
--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - python
     - gitpython
     - path_helpers
+    - paver
 
   run:
     - gitpython

--- a/constructor_git/__init__.py
+++ b/constructor_git/__init__.py
@@ -28,6 +28,7 @@ def render_template_directory(template_root, output_root, context=None,
     '''
     import jinja2
     import path_helpers as ph
+    import yaml
 
     output_root = ph.path(output_root)
     template_root = ph.path(template_root)
@@ -54,6 +55,22 @@ def render_template_directory(template_root, output_root, context=None,
 
                 with output_path.open('w') as output:
                     output.write(text)
+
+        # Add additional channels to construct.yaml file
+        if 'channels' in kwargs:
+            channels = kwargs['channels']
+            if channels:
+                if type(channels) == str: channels = [channels]
+                _ , extension = output_path.splitext()
+                with output_path.open('r') as f: construct_data = yaml.load(f)
+                if extension is ".yaml":
+                    if 'channels' in construct_data:
+                        construct_data['channels'] += channels
+                    if 'conda_default_channels' in construct_data:
+                        construct_data['conda_default_channels'] += channels
+                    with output_path.open('w') as f:
+                        f.write(yaml.dump(construct_data))
+
     return output_root
 
 

--- a/constructor_git/__main__.py
+++ b/constructor_git/__main__.py
@@ -6,7 +6,7 @@ import path_helpers as ph
 from . import CRE_DESCRIBE, build_miniconda_exe
 
 
-def main(repo_root):
+def main(repo_root,channels=None):
     repo_root = ph.path(repo_root).realpath()
     output_dir = ph.path(os.getcwd()).realpath()
     try:
@@ -16,7 +16,8 @@ def main(repo_root):
                                                                '--dirty']))
 
         build_miniconda_exe('.miniconda-recipe', output_dir,
-                            context=describe_match.groupdict())
+                            context=describe_match.groupdict(),
+                            channels=channels)
     finally:
         os.chdir(output_dir)
 


### PR DESCRIPTION
Add custom channels to construct.yaml file. Can use in conjunction with pavement via code snippets like so:

``` python

@task
@cmdopts([
    ('channel=', 'c', 'Extra conda channel for install')
])
def build_installer(options):
    try:
        import constructor_git as cg
        import constructor_git.__main__
    except ImportError:
        print >> sys.stderr, ('`constructor-git` package not found.  Install '
                              'with `conda install constructor-git`.')
        raise SystemExit(-1)

    repo_path = path(__file__).parent.realpath()
    cg.__main__.main(repo_path,channels=options.channel)

```